### PR TITLE
Controls are not prefilled in dish edit mode

### DIFF
--- a/app/controllers/Menu.php
+++ b/app/controllers/Menu.php
@@ -24,7 +24,7 @@ class Menu extends SecureController {
             $dish = new \models\Dishes();
         } else {
             $dishModel = new \models\Dishes();
-            $dish = $dishModel->getDishByUser(Security::get()->currentUser()->id, $id);
+            $dish = $dishModel->getDishByUser($id, Security::get()->currentUser()->id);
         }
 
         $form = new \forms\Dish();


### PR DESCRIPTION
# Bug reconstruction
- Log in as restaurant owner
- Go to your menu
- If there are no dishes yet, create one first
- Edit one of the existing (or the recently created dish)
- Name, Price, Category and Description controls are empty
# Cause

The pararameters when calling getDishByUser() where swapped.
