### PR TITLE
Integration of lmvc-utils

### DIFF
--- a/app/Bootstrap.php
+++ b/app/Bootstrap.php
@@ -4,6 +4,7 @@ use troba\EQM\EQM;
 use Scandio\lmvc\LVC;
 use Scandio\lmvc\modules\assetpipeline;
 use Scandio\lmvc\modules\upload;
+use Scandio\lmvc\utils\logger;
 
 class Bootstrap extends \Scandio\lmvc\utils\bootstrap\Bootstrap
 {
@@ -23,5 +24,6 @@ class Bootstrap extends \Scandio\lmvc\utils\bootstrap\Bootstrap
         ]);
 
         assetpipeline\Bootstrap::configure(static::getPath());
+        logger\Bootstrap::configure(static::getPath());
     }
 }

--- a/app/Bootstrap.php
+++ b/app/Bootstrap.php
@@ -5,7 +5,7 @@ use Scandio\lmvc\LVC;
 use Scandio\lmvc\modules\assetpipeline;
 use Scandio\lmvc\modules\upload;
 
-class Bootstrap extends \Scandio\lmvc\Bootstrap
+class Bootstrap extends \Scandio\lmvc\utils\bootstrap\Bootstrap
 {
     public function initialize()
     {

--- a/app/logs/.gitignore
+++ b/app/logs/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "require": {
         "php": ">=5.4",
         "scandio/lmvc": "dev-master",
-        "scandio/lmvc-utils": "dev-feature/psr3-logger",
         "scandio/troba": "dev-master",
         "scandio/lmvc-modules": "dev-master"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "php": ">=5.4",
         "scandio/lmvc": "dev-master",
+        "scandio/lmvc-utils": "dev-feature/psr3-logger",
         "scandio/troba": "dev-master",
         "scandio/lmvc-modules": "dev-master"
     },
@@ -30,6 +31,10 @@
        {
          "type": "git",
          "url": "https://github.com/SEP007/lmvc-troba.git"
+       },
+       {
+         "type": "git",
+         "url": "https://github.com/SEP007/lmvc-utils.git"
        }
     ],
     "require-dev": {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -28,6 +28,7 @@ if [ "$SET_CHMOD" == true ]
       chmod 0777 app/styles/_cache
       chmod 0777 app/fonts/_cache
       chmod 0777 app/markdown/_cache
+      chmod 0777 app/logs
 else
       echo "3.) NOT setting any chmods for caching directories..."
 fi


### PR DESCRIPTION
Lmvc-utils will refactor and aggregate some commonly used code among `lmvc`, `lmvc-modules` and `lmvc-troba`. This is pull-request keeps track of integrating the new `lmvc-utils` project into `lmvc-patat`.
