### PR TITLE
As a developer, I want to limit restaurants to advertise only 3 dishes.

### DIFF
--- a/app/models/Dishes.php
+++ b/app/models/Dishes.php
@@ -183,4 +183,22 @@ class Dishes
             return round($this->distance, 2) . ' km';
         }
     }
+
+    /**
+     * Get dishes by user id
+     * @param $userId user id
+     * @param bool $advertised if true then only advertised dishes are returned, otherwise only not advertised
+     * @return array dishes by user id
+     */
+    public function getDishesByUserId($userId, $advertised = false) {
+        $dishes = static::query()
+            ->select('*')
+            ->innerJoin(new Locations(), 'Dishes.user_id = Locations.user_id')
+            ->where('Locations.user_id = :userId', ['userId' => $userId])
+            ->andWhere('Dishes.advertised = :advertised', ['advertised' => (string) $advertised])
+            ->orderBy('Dishes.name')
+            ->all();
+
+        return $dishes;
+    }
 }

--- a/app/views/menu/edit.html
+++ b/app/views/menu/edit.html
@@ -19,9 +19,12 @@
     </div>
 
     <div class="span7">
-        <form id="menu-form" method="POST" action="<?= $app->url('Menu::edit', $dish->id) ?>">
+        <?php if($disableAdvertise): ?>
+            <label style="color:red">Only three dishes can be advertised!</label>
+        <?php endif; ?>
+        <form id="menu-form" method="POST" action="<?= $app->url('Menu::save', $dish->id) ?>">
             <fieldset>
-                <?= UI::checkbox('advertised', 'Advertise', (bool) $dish->advertised, $dish-advertised, $errors['advertised'], false) ?>
+                <?= UI::checkbox('advertised', 'Advertise', (bool) $dish->advertised, $dish-advertised, $errors['advertised'], $disableAdvertise) ?>
                 <?= UI::textField('name', null, $dish->name, $errors['name'], 'Name') ?>
                 <?= UI::combobox('category', null, $dish->category_id, $categories, 'id', 'name', $errors['category'], 'Category') ?>
                 <?= UI::textField('price', null, $dish->price, $errors['price'], 'Price', false, '€') ?>


### PR DESCRIPTION
Decription
Patat does not specify how many dishes can be advertised. This way, restaurants have the ability to mark every item of their menu as being on offer.

Checklist
- [x] Check how many dishes are advertised already before edit view is opened
- [x] Disable checkbox in case three dishes are already advertise and display some information on that
- [x] Refactore code in Menu.php, so that it is more obvious which code is executed when

@Guido46 Task is ready for review
